### PR TITLE
fix: Back-port the disconnected cluster fixes

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1,10 +1,12 @@
 import abc
 import ast
 import logging
+import os
 import random
 import re
 from collections.abc import Callable
-from copy import deepcopy
+from pathlib import Path
+from copy import copy, deepcopy
 from dataclasses import asdict, dataclass
 from inspect import getsource
 from typing import (
@@ -21,6 +23,7 @@ from typing import (
 )
 
 import datasets
+from datasets import DownloadConfig
 import numpy as np
 from tqdm import tqdm
 
@@ -49,6 +52,57 @@ ALL_OUTPUT_TYPES = [
 ]
 
 eval_logger = logging.getLogger(__name__)
+
+
+def _offline_datasetdict_bundle_dir(
+    hf_home: Optional[str], dataset_path: str, dataset_name: Optional[str]
+) -> Optional[Path]:
+    """Resolve ``HF_HOME/<slug>/`` when it contains ``dataset_dict.json`` (DatasetDict export layout).
+
+    ``hf_home`` must come from the environment (e.g. ``HF_HOME``); if unset, returns ``None``.
+
+    Slug is ``dataset_path`` with ``/`` replaced by ``--``. If ``dataset_name`` is set (subset),
+    append ``--`` + ``dataset_name``. When there is no subset (e.g. ``hellaswag``, ``blimp``),
+    only the path segment is used.
+    Example: ``allenai/ai2_arc`` + ``ARC-Easy`` -> ``allenai--ai2_arc--ARC-Easy`` under HF_HOME.
+    Example: ``hellaswag`` + ``None`` -> ``hellaswag`` under HF_HOME.
+    """
+    if not hf_home or not dataset_path:
+        return None
+    if dataset_name and ("/" in dataset_name or "\\" in dataset_name):
+        return None
+    root = Path(hf_home).resolve()
+    slug = dataset_path.replace("/", "--")
+    if dataset_name:
+        slug += "--" + dataset_name
+    if not slug or ".." in slug:
+        return None
+    bundle = (root / slug).resolve()
+    try:
+        bundle.relative_to(root)
+    except ValueError:
+        return None
+    if not (bundle / "dataset_dict.json").is_file():
+        return None
+    return bundle
+
+
+def _load_datasetdict_from_offline_bundle(bundle: Path) -> Any:
+    """Load a DatasetDict export from disk; clarify failures caused by datasets/PyArrow version skew."""
+    try:
+        return datasets.load_from_disk(str(bundle))
+    except TypeError as exc:
+        # e.g. Features.from_dict -> "must be called with a dataclass type or instance" when
+        # dataset_info.json was produced by a different `datasets` major than this runtime.
+        if "dataclass" in str(exc).lower():
+            raise RuntimeError(
+                f"Offline load_from_disk failed for {bundle}: on-disk metadata is incompatible "
+                "with this `datasets` build (usually the bundle was saved with another "
+                "`datasets`/PyArrow version). Re-run DatasetDict.save_to_disk using the same "
+                f"`datasets` and `pyarrow` versions as the eval image (here: datasets {datasets.__version__}), "
+                "then re-upload."
+            ) from exc
+        raise
 
 
 @dataclass
@@ -265,12 +319,38 @@ class Task(abc.ABC):
             - `datasets.DownloadMode.FORCE_REDOWNLOAD`
                 Fresh download and fresh dataset.
         """
+        offline = (
+            os.environ.get("HF_DATASETS_OFFLINE") == "1"
+            or os.environ.get("HF_HUB_OFFLINE") == "1"
+        )
+
+        if offline:
+            bundle = _offline_datasetdict_bundle_dir(
+                os.environ.get("HF_HOME"),
+                self.DATASET_PATH,
+                self.DATASET_NAME,
+            )
+            if bundle is not None:
+                eval_logger.info(
+                    "Offline: loading DatasetDict bundle at %s",
+                    bundle,
+                )
+                self.dataset = _load_datasetdict_from_offline_bundle(bundle)
+                return
+
+        kwargs: Dict[str, Any] = {
+            "data_dir": data_dir,
+            "cache_dir": cache_dir,
+            "download_mode": download_mode,
+        }
+        # Offline: standard datasets.load_dataset — rely on HF_HOME (hub + datasets caches from offline mirror).
+        if offline:
+            kwargs["download_config"] = DownloadConfig(local_files_only=True)
+
         self.dataset = datasets.load_dataset(
             path=self.DATASET_PATH,
             name=self.DATASET_NAME,
-            data_dir=data_dir,
-            cache_dir=cache_dir,
-            download_mode=download_mode,
+            **kwargs,
         )
 
     @property
@@ -931,10 +1011,45 @@ class ConfigurableTask(Task):
                     )
 
     def download(self, dataset_kwargs: Optional[Dict[str, Any]] = None) -> None:
+        kwargs = dict(dataset_kwargs if dataset_kwargs is not None else {})
+        offline = (
+            os.environ.get("HF_DATASETS_OFFLINE") == "1"
+            or os.environ.get("HF_HUB_OFFLINE") == "1"
+        )
+        if offline:
+            bundle = _offline_datasetdict_bundle_dir(
+                os.environ.get("HF_HOME"),
+                self.DATASET_PATH,
+                self.DATASET_NAME,
+            )
+            if bundle is not None:
+                eval_logger.info(
+                    "Offline: loading DatasetDict bundle at %s",
+                    bundle,
+                )
+                self.dataset = _load_datasetdict_from_offline_bundle(bundle)
+                return
+        # Offline: standard datasets.load_dataset — rely on HF_HOME caches; merge local_files_only into download_config.
+        if offline:
+            existing = kwargs.get("download_config")
+            if existing is None:
+                dc = DownloadConfig(local_files_only=True)
+            else:
+                try:
+                    dc = copy(existing)
+                    dc.local_files_only = True
+                except (TypeError, AttributeError) as exc:
+                    eval_logger.warning(
+                        "Offline: failed to copy existing download_config (%s); falling back to local_files_only DownloadConfig",
+                        exc,
+                    )
+                    dc = DownloadConfig(local_files_only=True)
+            kwargs["download_config"] = dc
+
         self.dataset = datasets.load_dataset(
             path=self.DATASET_PATH,
             name=self.DATASET_NAME,
-            **dataset_kwargs if dataset_kwargs is not None else {},
+            **kwargs,
         )
 
     def has_training_docs(self) -> bool:

--- a/main.py
+++ b/main.py
@@ -11,6 +11,10 @@ Optional environment variables:
 - EVALHUB_JOB_SPEC_PATH: path to the job spec JSON (defaults to `meta/job.json`)
 - REGISTRY_USERNAME: Registry username (optional)
 - REGISTRY_PASSWORD: Registry password/token (optional)
+
+Disconnected clusters: set `"offline": true` under `parameters` in the job spec so HF libraries use
+local caches under HF_HOME (default `/test_data`). The offline flag is read once from JSON before
+importing lm_eval so Hugging Face env vars apply in time.
 """
 
 import json
@@ -21,6 +25,53 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+_TEST_DATA_DIR = "/test_data"
+
+
+def _job_spec_file_requests_offline() -> bool:
+    """Read parameters.offline from job JSON only (no JobSpec yet). Used to set HF env before lm_eval import."""
+    path = os.environ.get("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            spec = json.load(f)
+        if not isinstance(spec, dict):
+            return False
+        parameters = spec.get("parameters")
+        if not isinstance(parameters, dict):
+            parameters = {}
+        return bool(parameters.get("offline"))
+    except FileNotFoundError:
+        return False
+    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        print(
+            f"WARNING: failed to read job spec for offline mode from {path!r}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+
+
+def configure_hf_offline_environment(hf_home: str) -> None:
+    """Use local Hugging Face caches only (disconnected / no huggingface.co).
+
+    Pin Hub/datasets cache dirs under hf_home so lookups match /test_data layout after init sync.
+    HF_HOME, HF_HUB_CACHE and HF_DATASETS_CACHE are set consistently so they stay aligned.
+    """
+    root = Path(hf_home)
+    os.environ["HF_HOME"] = str(root)
+    os.environ["HF_HUB_CACHE"] = str(root / "hub")
+    os.environ["HF_DATASETS_CACHE"] = str(root / "datasets")
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["HF_DATASETS_OFFLINE"] = "1"
+    os.environ["HF_EVALUATE_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+
+
+def _seed_hf_offline_before_lm_eval_import() -> None:
+    if not _job_spec_file_requests_offline():
+        return
+    configure_hf_offline_environment(os.environ.get("HF_HOME", _TEST_DATA_DIR))
+
 
 from evalhub.adapter import (
     DefaultCallbacks,
@@ -38,8 +89,13 @@ from evalhub.adapter import (
 )
 from evalhub.adapter.auth import read_model_auth_key, resolve_model_credentials
 
-from lm_eval import simple_evaluate
-from lm_eval.tasks import TaskManager
+
+_seed_hf_offline_before_lm_eval_import()
+
+# NOTE: keep these imports after _seed_hf_offline_before_lm_eval_import() so HF offline env vars
+# are set before lm_eval (and Hugging Face libraries) are imported.
+from lm_eval import simple_evaluate  # noqa: E402
+from lm_eval.tasks import TaskManager  # noqa: E402
 
 
 # Configure logging
@@ -190,18 +246,15 @@ class LMEvalAdapter(FrameworkAdapter):
             # use only local data from /test_data (populated by the init container
             # from S3 via test_data_ref).  This covers both datasets and tokenizers.
             if config.parameters.get("offline"):
-                test_data_dir = "/test_data"
+                test_data_dir = _TEST_DATA_DIR
                 if not os.path.isdir(test_data_dir):
                     raise RuntimeError(
                         f"Offline mode requested but {test_data_dir} does not exist. "
                         "Ensure test_data_ref is configured so the init container "
                         "populates the directory before the adapter starts."
                     )
-                os.environ["HF_HOME"] = test_data_dir
-                os.environ["HF_HUB_OFFLINE"] = "1"
-                os.environ["HF_DATASETS_OFFLINE"] = "1"
-                os.environ["HF_EVALUATE_OFFLINE"] = "1"
-                os.environ["TRANSFORMERS_OFFLINE"] = "1"
+                # Idempotent re-apply: import-time seed may have set HF_* from the same job JSON.
+                configure_hf_offline_environment(test_data_dir)
                 logger.info(
                     "Offline mode enabled: HF_HOME=%s, downloads disabled",
                     test_data_dir,

--- a/main.py
+++ b/main.py
@@ -8,13 +8,18 @@ Required environment variables:
 - REGISTRY_URL: OCI registry URL
 
 Optional environment variables:
-- EVALHUB_JOB_SPEC_PATH: path to the job spec JSON (defaults to `meta/job.json`)
+- EVALHUB_JOB_SPEC_PATH: path to the job spec JSON (defaults to ``/meta/job.json``); must resolve under ``/meta``
 - REGISTRY_USERNAME: Registry username (optional)
 - REGISTRY_PASSWORD: Registry password/token (optional)
 
-Disconnected clusters: set `"offline": true` under `parameters` in the job spec so HF libraries use
-local caches under HF_HOME (default `/test_data`). The offline flag is read once from JSON before
-importing lm_eval so Hugging Face env vars apply in time.
+Offline / air-gapped clusters: The job file is read before ``lm_eval`` loads (see
+``_seed_hf_offline_before_lm_eval_import``). The adapter only checks top-level
+``parameters.tokenizer``—the same tokenizer path used everywhere else, not anything under nested
+``parameters.parameters``. If that path exists on disk, sits under ``/test_data`` but is not the
+``/test_data`` mount path by itself, and another folder next to it under ``/test_data`` contains
+``dataset_dict.json`` (offline dataset files, e.g. next to ``tokenizer/``), the adapter turns on
+Hugging Face offline mode: it sets ``HF_HOME`` and related env vars so those libraries use local
+files and do not call the Hub. You do not need ``parameters.offline``.
 """
 
 import json
@@ -27,28 +32,150 @@ from pathlib import Path
 from typing import Any
 
 _TEST_DATA_DIR = "/test_data"
+# EvalHub mounts the job spec JSON under this directory only; reject other paths (CWE-22).
+_JOB_SPEC_ALLOWED_ROOT = Path("/meta")
 
 
-def _job_spec_file_requests_offline() -> bool:
-    """Read parameters.offline from job JSON only (no JobSpec yet). Used to set HF env before lm_eval import."""
-    path = os.environ.get("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")
+def _resolve_job_spec_path_for_read(path: str) -> Path | None:
+    """Return a resolved path to open, or None if ``path`` is invalid or escapes ``/meta``."""
+    if not isinstance(path, str) or not path.strip():
+        print("WARNING: job spec path is empty; refusing to open", file=sys.stderr)
+        return None
     try:
-        with open(path, encoding="utf-8") as f:
-            spec = json.load(f)
-        if not isinstance(spec, dict):
-            return False
-        parameters = spec.get("parameters")
-        if not isinstance(parameters, dict):
-            parameters = {}
-        return bool(parameters.get("offline"))
-    except FileNotFoundError:
-        return False
-    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        resolved = Path(path.strip()).resolve()
+    except (OSError, ValueError) as exc:
+        print(f"WARNING: invalid job spec path {path!r}: {exc}", file=sys.stderr)
+        return None
+    try:
+        allowed = _JOB_SPEC_ALLOWED_ROOT.resolve()
+    except OSError:
+        allowed = _JOB_SPEC_ALLOWED_ROOT
+    if not resolved.is_relative_to(allowed):
         print(
-            f"WARNING: failed to read job spec for offline mode from {path!r}: {exc}",
+            f"WARNING: job spec path {path!r} resolves to {resolved} "
+            f"which is not under {allowed}; refusing to open",
             file=sys.stderr,
         )
+        return None
+    return resolved
+
+
+def _read_job_spec_parameters_from_path(path: str) -> dict[str, Any]:
+    """Load top-level ``parameters`` object from the job spec JSON file.
+
+    Only files whose resolved path stays under ``/meta`` are opened (see ``EVALHUB_JOB_SPEC_PATH``).
+    """
+    resolved = _resolve_job_spec_path_for_read(path)
+    if resolved is None:
+        return {}
+    try:
+        with open(resolved, encoding="utf-8") as f:
+            spec = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except PermissionError as exc:
+        print(
+            f"WARNING: permission denied reading job spec {resolved!r}: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+    except OSError as exc:
+        print(f"WARNING: I/O error reading job spec {resolved!r}: {exc}", file=sys.stderr)
+        return {}
+    except json.JSONDecodeError as exc:
+        print(f"WARNING: invalid JSON in job spec {resolved!r}: {exc}", file=sys.stderr)
+        return {}
+    except TypeError as exc:
+        print(
+            f"WARNING: unexpected type while parsing job spec {resolved!r}: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+    if not isinstance(spec, dict):
+        return {}
+    parameters = spec.get("parameters")
+    if not isinstance(parameters, dict):
+        return {}
+    return parameters
+
+
+def _extract_tokenizer_parameter(parameters: dict[str, Any]) -> str | None:
+    """Tokenizer path or id from benchmark ``parameters.tokenizer`` (must match ``build_lmeval_config``).
+
+    Only the top-level key is used—the same source as ``model_args["tokenizer"]``—so HF offline
+    auto-detection never diverges from the tokenizer the adapter actually loads.
+    """
+    raw = parameters.get("tokenizer")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
+def _dataset_material_present_under_test_data(
+    root_resolved: Path, tokenizer_resolved: Path
+) -> bool:
+    """True when a DatasetDict bundle (``dataset_dict.json``) exists beside the tokenizer path.
+
+    Both paths must already be ``Path.resolve()`` results. Matches EvalHub ``/test_data`` sync:
+    e.g. ``tokenizer/`` and ``allenai--ai2_arc--ARC-Easy/`` as direct children of the mount.
+    """
+    try:
+        for child in root_resolved.iterdir():
+            if not child.is_dir():
+                continue
+            try:
+                cres = child.resolve()
+            except OSError:
+                continue
+            if cres == tokenizer_resolved:
+                continue
+            if tokenizer_resolved.is_relative_to(cres):
+                continue
+            if (child / "dataset_dict.json").is_file():
+                return True
+    except OSError:
         return False
+
+    return False
+
+
+def _infer_auto_offline_from_local_test_data(
+    parameters: dict[str, Any],
+    *,
+    test_data_root: str | Path = _TEST_DATA_DIR,
+) -> bool:
+    """True when ``parameters.tokenizer`` points into ``test_data_root`` and datasets are co-located.
+
+    Tokenizer: absolute path under ``test_data_root``, not the mount root alone, path exists.
+    Datasets: see ``_dataset_material_present_under_test_data`` (same ``/test_data`` directory).
+    """
+    tokenizer_str = _extract_tokenizer_parameter(parameters)
+    if not tokenizer_str or not tokenizer_str.startswith("/"):
+        return False
+
+    root = Path(test_data_root)
+    try:
+        root_res = root.resolve()
+    except OSError:
+        return False
+    if not root_res.is_dir():
+        return False
+
+    tokenizer_path = Path(tokenizer_str)
+    try:
+        tok_res = tokenizer_path.resolve()
+    except OSError:
+        return False
+
+    if tok_res == root_res or not tok_res.is_relative_to(root_res):
+        return False
+    try:
+        if not tok_res.exists():
+            return False
+    except OSError:
+        return False
+
+    return _dataset_material_present_under_test_data(root_res, tok_res)
 
 
 def configure_hf_offline_environment(hf_home: str) -> None:
@@ -68,9 +195,10 @@ def configure_hf_offline_environment(hf_home: str) -> None:
 
 
 def _seed_hf_offline_before_lm_eval_import() -> None:
-    if not _job_spec_file_requests_offline():
+    path = os.environ.get("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")
+    if not _infer_auto_offline_from_local_test_data(_read_job_spec_parameters_from_path(path)):
         return
-    configure_hf_offline_environment(os.environ.get("HF_HOME", _TEST_DATA_DIR))
+    configure_hf_offline_environment(_TEST_DATA_DIR)
 
 
 from evalhub.adapter import (
@@ -242,21 +370,24 @@ class LMEvalAdapter(FrameworkAdapter):
         start_time = time.time()
 
         try:
-            # When offline mode is enabled, configure HuggingFace libraries to
-            # use only local data from /test_data (populated by the init container
-            # from S3 via test_data_ref).  This covers both datasets and tokenizers.
-            if config.parameters.get("offline"):
+            # Auto-detect disconnected layout (see module docstring); re-apply HF env in case
+            # the import-time seed skipped (e.g. job file unreadable at process start).
+            benchmark_params = (
+                config.parameters if isinstance(config.parameters, dict) else {}
+            )
+            hf_offline = _infer_auto_offline_from_local_test_data(benchmark_params)
+            if hf_offline:
                 test_data_dir = _TEST_DATA_DIR
                 if not os.path.isdir(test_data_dir):
                     raise RuntimeError(
-                        f"Offline mode requested but {test_data_dir} does not exist. "
-                        "Ensure test_data_ref is configured so the init container "
-                        "populates the directory before the adapter starts."
+                        f"Local /test_data layout detected from parameters.tokenizer but "
+                        f"{test_data_dir} does not exist. Ensure test_data_ref is configured so "
+                        "the init container populates the directory before the adapter starts."
                     )
-                # Idempotent re-apply: import-time seed may have set HF_* from the same job JSON.
                 configure_hf_offline_environment(test_data_dir)
                 logger.info(
-                    "Offline mode enabled: HF_HOME=%s, downloads disabled",
+                    "HF offline mode (auto-detected from parameters.tokenizer + /test_data): "
+                    "HF_HOME=%s, downloads disabled",
                     test_data_dir,
                 )
 
@@ -286,7 +417,6 @@ class LMEvalAdapter(FrameworkAdapter):
             num_examples = config.num_examples
 
             # Adapter-specific params from parameters
-            benchmark_params = config.parameters
             num_fewshot = int(benchmark_params.get("num_few_shot", 0))
             random_seed = int(benchmark_params.get("random_seed", 42))
 

--- a/tests/test_adapter_offline_inference.py
+++ b/tests/test_adapter_offline_inference.py
@@ -1,0 +1,92 @@
+"""Tests for HF offline auto-detection from ``parameters.tokenizer`` + ``/test_data`` (no ``offline`` flag)."""
+
+from pathlib import Path
+
+import pytest
+
+from main import _infer_auto_offline_from_local_test_data
+
+
+def _touch(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{}", encoding="utf-8")
+
+
+@pytest.fixture
+def fake_test_data(tmp_path: Path) -> Path:
+    """Typical EvalHub sync: ``tokenizer/`` + slug bundle with ``dataset_dict.json``."""
+    root = tmp_path / "test_data"
+    tok = root / "tokenizer"
+    tok.mkdir(parents=True)
+    _touch(tok / "config.json")
+    bundle = root / "allenai--ai2_arc--ARC-Easy"
+    bundle.mkdir(parents=True)
+    _touch(bundle / "dataset_dict.json")
+    return root
+
+
+def test_infer_true_when_tokenizer_and_slug_bundle(fake_test_data: Path) -> None:
+    tok_path = fake_test_data / "tokenizer"
+    params = {"tokenizer": str(tok_path.resolve())}
+    assert _infer_auto_offline_from_local_test_data(params, test_data_root=fake_test_data)
+
+
+def test_nested_parameters_tokenizer_does_not_trigger_offline(fake_test_data: Path) -> None:
+    """Nested ``parameters.parameters.tokenizer`` is not used by ``build_lmeval_config``; infer must match."""
+    tok_path = fake_test_data / "tokenizer"
+    params = {
+        "tokenizer": "google/flan-t5-small",
+        "parameters": {"tokenizer": str(tok_path.resolve())},
+    }
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_hf_model_id(fake_test_data: Path) -> None:
+    params = {"tokenizer": "google/flan-t5-small"}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_tokenizer_path_missing(fake_test_data: Path) -> None:
+    missing = fake_test_data / "nope"
+    params = {"tokenizer": str(missing.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_no_dataset_dict_sibling(fake_test_data: Path) -> None:
+    """No ``dataset_dict.json`` under a sibling dir → do not infer offline."""
+    bundle = fake_test_data / "allenai--ai2_arc--ARC-Easy"
+    (bundle / "dataset_dict.json").unlink(missing_ok=True)
+    bundle.rmdir()
+    tok_path = fake_test_data / "tokenizer"
+    params = {"tokenizer": str(tok_path.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_tokenizer_is_root_only(fake_test_data: Path) -> None:
+    params = {"tokenizer": str(fake_test_data.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_path_outside_root(tmp_path: Path) -> None:
+    root = tmp_path / "test_data"
+    root.mkdir()
+    bundle = root / "some--dataset"
+    bundle.mkdir(parents=True)
+    _touch(bundle / "dataset_dict.json")
+    outside = tmp_path / "other" / "tok"
+    outside.mkdir(parents=True)
+    _touch(outside / "config.json")
+    params = {"tokenizer": str(outside.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=root
+    )

--- a/tests/test_job_spec_parameters_path.py
+++ b/tests/test_job_spec_parameters_path.py
@@ -1,0 +1,46 @@
+"""Tests for job spec path validation in ``_read_job_spec_parameters_from_path``."""
+
+from pathlib import Path
+
+import pytest
+
+import main
+
+
+def test_resolve_rejects_path_outside_meta() -> None:
+    assert main._resolve_job_spec_path_for_read("/tmp/job.json") is None
+
+
+def test_resolve_rejects_dotdot_escape() -> None:
+    assert main._resolve_job_spec_path_for_read("/meta/../etc/passwd") is None
+
+
+def test_resolve_accepts_meta_job_json() -> None:
+    resolved = main._resolve_job_spec_path_for_read("/meta/job.json")
+    assert resolved is not None
+    assert resolved == Path("/meta/job.json").resolve()
+
+
+def test_read_parameters_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(main, "_JOB_SPEC_ALLOWED_ROOT", tmp_path)
+    job = tmp_path / "job.json"
+    job.write_text('{"parameters": {"limit": 3}}', encoding="utf-8")
+    assert main._read_job_spec_parameters_from_path(str(job)) == {"limit": 3}
+
+
+def test_read_parameters_missing_file_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(main, "_JOB_SPEC_ALLOWED_ROOT", tmp_path)
+    assert main._read_job_spec_parameters_from_path(str(tmp_path / "nope.json")) == {}
+
+
+def test_read_parameters_invalid_json_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(main, "_JOB_SPEC_ALLOWED_ROOT", tmp_path)
+    job = tmp_path / "job.json"
+    job.write_text("{not-json", encoding="utf-8")
+    assert main._read_job_spec_parameters_from_path(str(job)) == {}
+    err = capsys.readouterr().err
+    assert "invalid JSON" in err


### PR DESCRIPTION
issue:
https://redhat.atlassian.net/browse/RHOAIENG-63792

This PR back-ports the disconnected cluster related fixes. 

Test Results:
1. Evaluation job with single benchmark
```
{
  "resource": {
    "id": "82765063-2140-4750-80af-67bf871c736e",
    "tenant": "dataplane",
    "created_at": "2026-05-21T06:03:21.572062Z",
    "updated_at": "2026-05-21T06:14:06.841082Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "blimp",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-05-21T06:14:06.809526+00:00"
      }
    ]
  },
  "results": {
    "test": {
      "score": 0.78791046,
      "threshold": 0.5,
      "pass": true
    },
    "benchmarks": [
      {
        "id": "blimp",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.787910447761194,
          "acc_stderr": 0.004522788330772838
        },
        "test": {
          "primary_score": 0.78791046,
          "primary_score_metric": "acc",
          "threshold": 0.25,
          "pass": true
        }
      }
    ]
  },
  "name": "model offline test",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct"
  },
  "benchmarks": [
    {
      "id": "blimp",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 100,
        "tokenizer": "/test_data/tokenizer"
      },
      "test_data_ref": {
        "s3": {
          "bucket": "mlpipeline",
          "key": "offline",
          "secret_ref": "minio-test"
        }
      }
    }
  ]
}
```

pod logs:
```
oc logs 82765063-2140-4750-80af-67-cea270e7-6ba5-4a10-a67c-64c2dad7kzzz  -f -n dataplane
Defaulted container "adapter" out of: adapter, init (init), sidecar (init)
2026-05-21 06:03:37,171 - evalhub.adapter.models.adapter - INFO - Loading job spec from /meta/job.json
2026-05-21 06:03:37,173 - __main__ - INFO - LMEval adapter initialized
2026-05-21 06:03:37,173 - __main__ - INFO - ================================================================================
2026-05-21 06:03:37,173 - __main__ - INFO - LMEval EvalHub Adapter
2026-05-21 06:03:37,173 - __main__ - INFO - ================================================================================
2026-05-21 06:03:37,173 - __main__ - INFO - Loaded job spec from: /meta/job.json
2026-05-21 06:03:37,173 - __main__ - INFO - Job spec configuration:
2026-05-21 06:03:37,173 - __main__ - INFO -   Job ID: 82765063-2140-4750-80af-67bf871c736e
2026-05-21 06:03:37,173 - __main__ - INFO -   Benchmark: blimp
2026-05-21 06:03:37,173 - __main__ - INFO -   Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-21 06:03:37,173 - __main__ - INFO -   Examples: 100
2026-05-21 06:03:37,173 - __main__ - INFO -   Few-shot: None
2026-05-21 06:03:37,173 - __main__ - INFO - ================================================================================
2026-05-21 06:03:37,173 - __main__ - INFO - Callback URL: http://localhost:8080
2026-05-21 06:03:37,173 - __main__ - INFO - Provider ID: lm_evaluation_harness
2026-05-21 06:03:37,173 - __main__ - INFO - OCI registry auth config present: False
2026-05-21 06:03:37,173 - __main__ - INFO - OCI insecure: False
2026-05-21 06:03:37,174 - __main__ - INFO - EvalHub insecure: False
2026-05-21 06:03:37,174 - __main__ - INFO - ================================================================================
2026-05-21 06:03:37,256 - __main__ - INFO - HF offline mode (auto-detected from parameters.tokenizer + /test_data): HF_HOME=/test_data, downloads disabled
2026-05-21 06:03:37,257 - __main__ - INFO - Concurrent requests are disabled (num_concurrent=1). Add num_concurrent to benchmark parameters to enable.
2026-05-21 06:03:37,284 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/82765063-2140-4750-80af-67bf871c736e/events "HTTP/1.1 204 No Content"
2026-05-21 06:03:37,284 - __main__ - INFO - Job ID: 82765063-2140-4750-80af-67bf871c736e
2026-05-21 06:03:37,284 - __main__ - INFO - Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-21 06:03:37,284 - __main__ - INFO - Benchmark: blimp
2026-05-21 06:03:37,284 - __main__ - INFO - Examples limit: 100
2026-05-21 06:03:37,284 - __main__ - INFO - Few-shot: 0
2026-05-21 06:03:37,284 - __main__ - INFO - Device: cpu (forced)
2026-05-21 06:03:37,284 - __main__ - INFO - Model backend: local-completions
2026-05-21 06:03:37,291 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/82765063-2140-4750-80af-67bf871c736e/events "HTTP/1.1 204 No Content"
2026-05-21 06:03:40,578 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/82765063-2140-4750-80af-67bf871c736e/events "HTTP/1.1 204 No Content"
2026-05-21 06:03:40,580 - lm_eval.evaluator - INFO - Setting random seed to 42 | Setting numpy seed to 42 | Setting torch manual seed to 42 | Setting fewshot manual seed to 1234
2026-05-21 06:03:40,580 - lm_eval.evaluator - INFO - Initializing local-completions model, with arguments: {'model': 'meta-llama/Llama-3.2-1B-Instruct', 'base_url': 'https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions', 'tokenizer_backend': 'huggingface', 'tokenizer': '/test_data/tokenizer', 'tokenized_requests': False, 'num_concurrent': 1, 'batch_size': 1, 'timeout': 300}
2026-05-21 06:03:40,580 - lm_eval.models.api_models - INFO - Using max length 2048 - 1
2026-05-21 06:03:40,580 - lm_eval.models.api_models - INFO - Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2026-05-21 06:03:40,580 - lm_eval.models.api_models - INFO - Using tokenizer huggingface
2026-05-21 06:03:41,152 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_vs_that_with_gap_long_distance
2026-05-21 06:03:41,247 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_vs_that_with_gap
2026-05-21 06:03:41,341 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_vs_that_no_gap_long_distance
2026-05-21 06:03:41,435 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_vs_that_no_gap
2026-05-21 06:03:41,478 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_questions_subject_gap_long_distance
2026-05-21 06:03:41,572 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_questions_subject_gap
2026-05-21 06:03:41,666 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_questions_object_gap
2026-05-21 06:03:41,760 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--wh_island
2026-05-21 06:03:41,853 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--transitive
2026-05-21 06:03:41,946 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--tough_vs_raising_2
2026-05-21 06:03:42,041 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--tough_vs_raising_1
2026-05-21 06:03:42,134 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--superlative_quantifiers_2
2026-05-21 06:03:42,177 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--superlative_quantifiers_1
2026-05-21 06:03:42,270 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--sentential_subject_island
2026-05-21 06:03:42,367 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--sentential_negation_npi_scope
2026-05-21 06:03:42,467 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--sentential_negation_npi_licensor_present
2026-05-21 06:03:42,562 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--regular_plural_subject_verb_agreement_2
2026-05-21 06:03:42,655 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--regular_plural_subject_verb_agreement_1
2026-05-21 06:03:42,748 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--principle_A_reconstruction
2026-05-21 06:03:42,842 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--principle_A_domain_3
2026-05-21 06:03:42,934 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--principle_A_domain_2
2026-05-21 06:03:42,977 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--principle_A_domain_1
2026-05-21 06:03:43,072 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--principle_A_case_2
2026-05-21 06:03:43,167 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--principle_A_case_1
2026-05-21 06:03:43,257 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--principle_A_c_command
2026-05-21 06:03:43,349 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--passive_2
2026-05-21 06:03:43,440 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--passive_1
2026-05-21 06:03:43,533 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--only_npi_scope
2026-05-21 06:03:43,574 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--only_npi_licensor_present
2026-05-21 06:03:43,665 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--npi_present_2
2026-05-21 06:03:43,756 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--npi_present_1
2026-05-21 06:03:43,848 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--matrix_question_npi_licensor_present
2026-05-21 06:03:43,937 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--left_branch_island_simple_question
2026-05-21 06:03:43,980 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--left_branch_island_echo_question
2026-05-21 06:03:44,072 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--irregular_plural_subject_verb_agreement_2
2026-05-21 06:03:44,164 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--irregular_plural_subject_verb_agreement_1
2026-05-21 06:03:44,254 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--irregular_past_participle_verbs
2026-05-21 06:03:44,346 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--irregular_past_participle_adjectives
2026-05-21 06:03:44,437 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--intransitive
2026-05-21 06:03:44,477 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--inchoative
2026-05-21 06:03:44,568 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--expletive_it_object_raising
2026-05-21 06:03:44,661 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--existential_there_subject_raising
2026-05-21 06:03:44,753 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--existential_there_quantifiers_2
2026-05-21 06:03:44,844 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--existential_there_quantifiers_1
2026-05-21 06:03:44,937 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--existential_there_object_raising
2026-05-21 06:03:44,978 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--ellipsis_n_bar_2
2026-05-21 06:03:45,071 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--ellipsis_n_bar_1
2026-05-21 06:03:45,163 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--drop_argument
2026-05-21 06:03:45,253 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--distractor_agreement_relative_clause
2026-05-21 06:03:45,353 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--distractor_agreement_relational_noun
2026-05-21 06:03:45,457 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_with_adjective_1
2026-05-21 06:03:45,549 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_with_adj_irregular_2
2026-05-21 06:03:45,639 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_with_adj_irregular_1
2026-05-21 06:03:45,681 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_with_adj_2
2026-05-21 06:03:45,773 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_irregular_2
2026-05-21 06:03:45,865 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_irregular_1
2026-05-21 06:03:45,957 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_2
2026-05-21 06:03:46,049 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--determiner_noun_agreement_1
2026-05-21 06:03:46,140 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--coordinate_structure_constraint_object_extraction

2026-05-21 06:03:46,232 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--coordinate_structure_constraint_complex_left_branch
2026-05-21 06:03:46,273 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--complex_NP_island
2026-05-21 06:03:46,365 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--causative
2026-05-21 06:03:46,456 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--animate_subject_trans
2026-05-21 06:03:46,546 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--animate_subject_passive
2026-05-21 06:03:46,636 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--anaphor_number_agreement
2026-05-21 06:03:46,677 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--anaphor_gender_agreement
2026-05-21 06:03:46,769 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/blimp--adjunct_island
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_adjunct_island in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_anaphor_gender_agreement in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_anaphor_number_agreement in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_animate_subject_passive in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_animate_subject_trans in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_causative in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_complex_NP_island in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_coordinate_structure_constraint_complex_left_branch in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_coordinate_structure_constraint_object_extraction in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_irregular_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_irregular_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_with_adj_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_with_adj_irregular_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_with_adj_irregular_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_determiner_noun_agreement_with_adjective_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_distractor_agreement_relational_noun in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_distractor_agreement_relative_clause in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_drop_argument in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_ellipsis_n_bar_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_ellipsis_n_bar_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_existential_there_object_raising in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_existential_there_quantifiers_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_existential_there_quantifiers_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_existential_there_subject_raising in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_expletive_it_object_raising in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_inchoative in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,860 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_intransitive in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_irregular_past_participle_adjectives in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_irregular_past_participle_verbs in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_irregular_plural_subject_verb_agreement_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_irregular_plural_subject_verb_agreement_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_left_branch_island_echo_question in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_left_branch_island_simple_question in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_matrix_question_npi_licensor_present in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_npi_present_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_npi_present_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_only_npi_licensor_present in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_only_npi_scope in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_passive_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_passive_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_principle_A_c_command in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_principle_A_case_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_principle_A_case_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_principle_A_domain_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_principle_A_domain_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_principle_A_domain_3 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_principle_A_reconstruction in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_regular_plural_subject_verb_agreement_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_regular_plural_subject_verb_agreement_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_sentential_negation_npi_licensor_present in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_sentential_negation_npi_scope in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_sentential_subject_island in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_superlative_quantifiers_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_superlative_quantifiers_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_tough_vs_raising_1 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_tough_vs_raising_2 in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_transitive in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_island in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_questions_object_gap in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_questions_subject_gap in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_questions_subject_gap_long_distance in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_vs_that_no_gap in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_vs_that_no_gap_long_distance in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_vs_that_with_gap in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,861 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for blimp_wh_vs_that_with_gap_long_distance in its config. Manual configuration will be ignored.
2026-05-21 06:03:46,864 - lm_eval.api.task - INFO - Building contexts for blimp_adjunct_island on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1002.61it/s]
2026-05-21 06:03:46,969 - lm_eval.api.task - INFO - Building contexts for blimp_anaphor_gender_agreement on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1013.05it/s]
2026-05-21 06:03:47,072 - lm_eval.api.task - INFO - Building contexts for blimp_anaphor_number_agreement on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1009.41it/s]
2026-05-21 06:03:47,175 - lm_eval.api.task - INFO - Building contexts for blimp_animate_subject_passive on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1011.52it/s]
2026-05-21 06:03:47,278 - lm_eval.api.task - INFO - Building contexts for blimp_animate_subject_trans on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1025.34it/s]
2026-05-21 06:03:47,380 - lm_eval.api.task - INFO - Building contexts for blimp_causative on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1017.88it/s]
2026-05-21 06:03:47,533 - lm_eval.api.task - INFO - Building contexts for blimp_complex_NP_island on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1015.78it/s]
2026-05-21 06:03:47,636 - lm_eval.api.task - INFO - Building contexts for blimp_coordinate_structure_constraint_complex_left_branch on rank 0...

100%|██████████| 100/100 [00:00<00:00, 1002.68it/s]
2026-05-21 06:03:47,740 - lm_eval.api.task - INFO - Building contexts for blimp_coordinate_structure_constraint_object_extraction on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1022.38it/s]
2026-05-21 06:03:47,842 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1012.20it/s]
2026-05-21 06:03:47,946 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 997.72it/s]
2026-05-21 06:03:48,050 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_irregular_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1010.76it/s]
2026-05-21 06:03:48,153 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_irregular_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1018.73it/s]
2026-05-21 06:03:48,256 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_with_adj_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 996.24it/s]
2026-05-21 06:03:48,361 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_with_adj_irregular_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1028.04it/s]
2026-05-21 06:03:48,463 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_with_adj_irregular_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1001.02it/s]
2026-05-21 06:03:48,568 - lm_eval.api.task - INFO - Building contexts for blimp_determiner_noun_agreement_with_adjective_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1018.75it/s]
2026-05-21 06:03:48,670 - lm_eval.api.task - INFO - Building contexts for blimp_distractor_agreement_relational_noun on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1015.28it/s]
2026-05-21 06:03:48,774 - lm_eval.api.task - INFO - Building contexts for blimp_distractor_agreement_relative_clause on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1003.36it/s]
2026-05-21 06:03:48,878 - lm_eval.api.task - INFO - Building contexts for blimp_drop_argument on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1017.56it/s]
2026-05-21 06:03:48,981 - lm_eval.api.task - INFO - Building contexts for blimp_ellipsis_n_bar_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1008.47it/s]
2026-05-21 06:03:49,133 - lm_eval.api.task - INFO - Building contexts for blimp_ellipsis_n_bar_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1018.23it/s]
2026-05-21 06:03:49,236 - lm_eval.api.task - INFO - Building contexts for blimp_existential_there_object_raising on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1008.00it/s]
2026-05-21 06:03:49,340 - lm_eval.api.task - INFO - Building contexts for blimp_existential_there_quantifiers_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1019.23it/s]
2026-05-21 06:03:49,442 - lm_eval.api.task - INFO - Building contexts for blimp_existential_there_quantifiers_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1017.70it/s]
2026-05-21 06:03:49,545 - lm_eval.api.task - INFO - Building contexts for blimp_existential_there_subject_raising on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1008.33it/s]
2026-05-21 06:03:49,648 - lm_eval.api.task - INFO - Building contexts for blimp_expletive_it_object_raising on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1013.89it/s]
2026-05-21 06:03:49,751 - lm_eval.api.task - INFO - Building contexts for blimp_inchoative on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1018.91it/s]
2026-05-21 06:03:49,854 - lm_eval.api.task - INFO - Building contexts for blimp_intransitive on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1019.18it/s]
2026-05-21 06:03:49,957 - lm_eval.api.task - INFO - Building contexts for blimp_irregular_past_participle_adjectives on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1006.39it/s]
2026-05-21 06:03:50,060 - lm_eval.api.task - INFO - Building contexts for blimp_irregular_past_participle_verbs on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1007.05it/s]
2026-05-21 06:03:50,164 - lm_eval.api.task - INFO - Building contexts for blimp_irregular_plural_subject_verb_agreement_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1010.18it/s]
2026-05-21 06:03:50,268 - lm_eval.api.task - INFO - Building contexts for blimp_irregular_plural_subject_verb_agreement_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 997.09it/s]
2026-05-21 06:03:50,373 - lm_eval.api.task - INFO - Building contexts for blimp_left_branch_island_echo_question on rank 0...
100%|██████████| 100/100 [00:00<00:00, 980.68it/s]
2026-05-21 06:03:50,480 - lm_eval.api.task - INFO - Building contexts for blimp_left_branch_island_simple_question on rank 0...
100%|██████████| 100/100 [00:00<00:00, 2042.15it/s]
2026-05-21 06:03:50,582 - lm_eval.api.task - INFO - Building contexts for blimp_matrix_question_npi_licensor_present on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1021.25it/s]
2026-05-21 06:03:50,735 - lm_eval.api.task - INFO - Building contexts for blimp_npi_present_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1016.19it/s]
2026-05-21 06:03:50,838 - lm_eval.api.task - INFO - Building contexts for blimp_npi_present_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1015.12it/s]
2026-05-21 06:03:50,941 - lm_eval.api.task - INFO - Building contexts for blimp_only_npi_licensor_present on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1002.70it/s]
2026-05-21 06:03:51,045 - lm_eval.api.task - INFO - Building contexts for blimp_only_npi_scope on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1008.27it/s]
2026-05-21 06:03:51,149 - lm_eval.api.task - INFO - Building contexts for blimp_passive_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1012.76it/s]
2026-05-21 06:03:51,252 - lm_eval.api.task - INFO - Building contexts for blimp_passive_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1021.97it/s]
2026-05-21 06:03:51,355 - lm_eval.api.task - INFO - Building contexts for blimp_principle_A_c_command on rank 0...
100%|██████████| 100/100 [00:00<00:00, 999.83it/s]
2026-05-21 06:03:51,460 - lm_eval.api.task - INFO - Building contexts for blimp_principle_A_case_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1012.88it/s]
2026-05-21 06:03:51,563 - lm_eval.api.task - INFO - Building contexts for blimp_principle_A_case_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1015.10it/s]
2026-05-21 06:03:51,666 - lm_eval.api.task - INFO - Building contexts for blimp_principle_A_domain_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1011.31it/s]
2026-05-21 06:03:51,769 - lm_eval.api.task - INFO - Building contexts for blimp_principle_A_domain_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1004.04it/s]
2026-05-21 06:03:51,873 - lm_eval.api.task - INFO - Building contexts for blimp_principle_A_domain_3 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1008.04it/s]
2026-05-21 06:03:51,977 - lm_eval.api.task - INFO - Building contexts for blimp_principle_A_reconstruction on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1019.37it/s]
2026-05-21 06:03:52,079 - lm_eval.api.task - INFO - Building contexts for blimp_regular_plural_subject_verb_agreement_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1010.56it/s]
2026-05-21 06:03:52,234 - lm_eval.api.task - INFO - Building contexts for blimp_regular_plural_subject_verb_agreement_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1019.00it/s]
2026-05-21 06:03:52,336 - lm_eval.api.task - INFO - Building contexts for blimp_sentential_negation_npi_licensor_present on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1003.54it/s]
2026-05-21 06:03:52,441 - lm_eval.api.task - INFO - Building contexts for blimp_sentential_negation_npi_scope on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1016.78it/s]
2026-05-21 06:03:52,543 - lm_eval.api.task - INFO - Building contexts for blimp_sentential_subject_island on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1000.53it/s]
2026-05-21 06:03:52,648 - lm_eval.api.task - INFO - Building contexts for blimp_superlative_quantifiers_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 988.62it/s]
2026-05-21 06:03:52,754 - lm_eval.api.task - INFO - Building contexts for blimp_superlative_quantifiers_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 971.13it/s]
2026-05-21 06:03:52,862 - lm_eval.api.task - INFO - Building contexts for blimp_tough_vs_raising_1 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1019.26it/s]
2026-05-21 06:03:52,964 - lm_eval.api.task - INFO - Building contexts for blimp_tough_vs_raising_2 on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1000.88it/s]
2026-05-21 06:03:53,069 - lm_eval.api.task - INFO - Building contexts for blimp_transitive on rank 0...
100%|██████████| 100/100 [00:00<00:00, 976.49it/s]
2026-05-21 06:03:53,176 - lm_eval.api.task - INFO - Building contexts for blimp_wh_island on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1017.29it/s]
2026-05-21 06:03:53,279 - lm_eval.api.task - INFO - Building contexts for blimp_wh_questions_object_gap on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1002.09it/s]
2026-05-21 06:03:53,432 - lm_eval.api.task - INFO - Building contexts for blimp_wh_questions_subject_gap on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1007.33it/s]
2026-05-21 06:03:53,536 - lm_eval.api.task - INFO - Building contexts for blimp_wh_questions_subject_gap_long_distance on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1020.39it/s]
2026-05-21 06:03:53,639 - lm_eval.api.task - INFO - Building contexts for blimp_wh_vs_that_no_gap on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1004.47it/s]
2026-05-21 06:03:53,743 - lm_eval.api.task - INFO - Building contexts for blimp_wh_vs_that_no_gap_long_distance on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1017.88it/s]
2026-05-21 06:03:53,846 - lm_eval.api.task - INFO - Building contexts for blimp_wh_vs_that_with_gap on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1005.78it/s]
2026-05-21 06:03:53,950 - lm_eval.api.task - INFO - Building contexts for blimp_wh_vs_that_with_gap_long_distance on rank 0...
100%|██████████| 100/100 [00:00<00:00, 1003.22it/s]
2026-05-21 06:03:54,054 - lm_eval.evaluator - INFO - Running loglikelihood requests
Requesting API: 100%|██████████| 13400/13400 [10:04<00:00, 22.18it/s]
fatal: not a git repository (or any of the parent directories): .git
2026-05-21 06:14:06,809 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/82765063-2140-4750-80af-67bf871c736e/events "HTTP/1.1 204 No Content"
2026-05-21 06:14:06,815 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/82765063-2140-4750-80af-67bf871c736e/events "HTTP/1.1 204 No Content"
2026-05-21 06:14:06,816 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-05-21 06:14:06,839 - __main__ - INFO - ================================================================================
2026-05-21 06:14:06,839 - __main__ - INFO - Evaluation completed successfully
2026-05-21 06:14:06,839 - __main__ - INFO - Overall score: 0.787910447761194
2026-05-21 06:14:06,839 - __main__ - INFO - Examples evaluated: 0
2026-05-21 06:14:06,839 - __main__ - INFO - Duration: 629.55s
2026-05-21 06:14:06,839 - __main__ - INFO - ================================================================================
2026-05-21 06:14:06,845 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/82765063-2140-4750-80af-67bf871c736e/events "HTTP/1.1 204 No Content"
2026-05-21 06:14:06,845 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 2 | Score: 0.787910447761194
2026-05-21 06:14:06,845 - evalhub.adapter.callbacks - INFO - Job 82765063-2140-4750-80af-67bf871c736e completed | Benchmark: blimp | Model: meta-llama/Llama-3.2-1B-Instruct | Score: 0.787910447761194 | Examples: 0 | Duration: 629.55s
```

2. Evaluation job with multiple benchmarks

```
{
  "resource": {
    "id": "031a87d2-6315-4b23-a0c7-2a55523759a4",
    "tenant": "dataplane",
    "created_at": "2026-05-21T06:04:41.074543Z",
    "updated_at": "2026-05-21T06:15:24.142985Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-05-21T06:05:16.662513+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "blimp",
        "benchmark_index": 1,
        "status": "completed",
        "completed_at": "2026-05-21T06:15:24.106924+00:00"
      }
    ]
  },
  "results": {
    "test": {
      "score": 0.7139552,
      "threshold": 0.5,
      "pass": true
    },
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.64,
          "acc_norm": 0.64,
          "acc_norm_stderr": 0.048241815132442176,
          "acc_stderr": 0.048241815132442176
        },
        "test": {
          "primary_score": 0.64,
          "primary_score_metric": "acc_norm",
          "threshold": 0.25,
          "pass": true
        }
      },
      {
        "id": "blimp",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 1,
        "metrics": {
          "acc": 0.787910447761194,
          "acc_stderr": 0.004522788330772838
        },
        "test": {
          "primary_score": 0.78791046,
          "primary_score_metric": "acc",
          "threshold": 0.25,
          "pass": true
        }
      }
    ]
  },
  "name": "model offline test",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 100,
        "tokenizer": "/test_data/tokenizer"
      },
      "test_data_ref": {
        "s3": {
          "bucket": "mlpipeline",
          "key": "offline",
          "secret_ref": "minio-test"
        }
      }
    },
    {
      "id": "blimp",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 100,
        "tokenizer": "/test_data/tokenizer"
      },
      "test_data_ref": {
        "s3": {
          "bucket": "mlpipeline",
          "key": "offline",
          "secret_ref": "minio-test"
        }
      }
    }
  ]
}
```
pod logs:
```
 oc logs 031a87d2-6315-4b23-a0c7-2a-59f70cb0-991e-4ade-9531-57125c3lczps -f -n dataplane 
Defaulted container "adapter" out of: adapter, init (init), sidecar (init)
2026-05-21 06:04:56,246 - evalhub.adapter.models.adapter - INFO - Loading job spec from /meta/job.json
2026-05-21 06:04:56,247 - __main__ - INFO - LMEval adapter initialized
2026-05-21 06:04:56,247 - __main__ - INFO - ================================================================================
2026-05-21 06:04:56,247 - __main__ - INFO - LMEval EvalHub Adapter
2026-05-21 06:04:56,247 - __main__ - INFO - ================================================================================
2026-05-21 06:04:56,247 - __main__ - INFO - Loaded job spec from: /meta/job.json
2026-05-21 06:04:56,248 - __main__ - INFO - Job spec configuration:
2026-05-21 06:04:56,248 - __main__ - INFO -   Job ID: 031a87d2-6315-4b23-a0c7-2a55523759a4
2026-05-21 06:04:56,248 - __main__ - INFO -   Benchmark: arc_easy
2026-05-21 06:04:56,248 - __main__ - INFO -   Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-21 06:04:56,248 - __main__ - INFO -   Examples: 100
2026-05-21 06:04:56,248 - __main__ - INFO -   Few-shot: None
2026-05-21 06:04:56,248 - __main__ - INFO - ================================================================================
2026-05-21 06:04:56,248 - __main__ - INFO - Callback URL: http://localhost:8080
2026-05-21 06:04:56,248 - __main__ - INFO - Provider ID: lm_evaluation_harness
2026-05-21 06:04:56,248 - __main__ - INFO - OCI registry auth config present: False
2026-05-21 06:04:56,248 - __main__ - INFO - OCI insecure: False
2026-05-21 06:04:56,248 - __main__ - INFO - EvalHub insecure: False
2026-05-21 06:04:56,248 - __main__ - INFO - ================================================================================
2026-05-21 06:04:56,280 - __main__ - INFO - HF offline mode (auto-detected from parameters.tokenizer + /test_data): HF_HOME=/test_data, downloads disabled
2026-05-21 06:04:56,281 - __main__ - INFO - Concurrent requests are disabled (num_concurrent=1). Add num_concurrent to benchmark parameters to enable.
2026-05-21 06:04:56,333 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/031a87d2-6315-4b23-a0c7-2a55523759a4/events "HTTP/1.1 204 No Content"
2026-05-21 06:04:56,333 - __main__ - INFO - Job ID: 031a87d2-6315-4b23-a0c7-2a55523759a4
2026-05-21 06:04:56,333 - __main__ - INFO - Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-21 06:04:56,333 - __main__ - INFO - Benchmark: arc_easy
2026-05-21 06:04:56,333 - __main__ - INFO - Examples limit: 100
2026-05-21 06:04:56,333 - __main__ - INFO - Few-shot: 0
2026-05-21 06:04:56,333 - __main__ - INFO - Device: cpu (forced)
2026-05-21 06:04:56,333 - __main__ - INFO - Model backend: local-completions
2026-05-21 06:04:56,339 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/031a87d2-6315-4b23-a0c7-2a55523759a4/events "HTTP/1.1 204 No Content"
2026-05-21 06:04:59,463 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/031a87d2-6315-4b23-a0c7-2a55523759a4/events "HTTP/1.1 204 No Content"
2026-05-21 06:04:59,465 - lm_eval.evaluator - INFO - Setting random seed to 42 | Setting numpy seed to 42 | Setting torch manual seed to 42 | Setting fewshot manual seed to 1234
2026-05-21 06:04:59,465 - lm_eval.evaluator - INFO - Initializing local-completions model, with arguments: {'model': 'meta-llama/Llama-3.2-1B-Instruct', 'base_url': 'https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions', 'tokenizer_backend': 'huggingface', 'tokenizer': '/test_data/tokenizer', 'tokenized_requests': False, 'num_concurrent': 1, 'batch_size': 1, 'timeout': 300}
2026-05-21 06:04:59,465 - lm_eval.models.api_models - INFO - Using max length 2048 - 1
2026-05-21 06:04:59,465 - lm_eval.models.api_models - INFO - Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2026-05-21 06:04:59,465 - lm_eval.models.api_models - INFO - Using tokenizer huggingface
2026-05-21 06:05:00,152 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/allenai--ai2_arc--ARC-Easy
2026-05-21 06:05:00,335 - lm_eval.evaluator - WARNING - Overwriting default num_fewshot of arc_easy from None to 0
2026-05-21 06:05:00,335 - lm_eval.api.task - INFO - Building contexts for arc_easy on rank 0...
100%|██████████| 100/100 [00:00<00:00, 902.36it/s]
2026-05-21 06:05:00,450 - lm_eval.evaluator - INFO - Running loglikelihood requests
Requesting API: 100%|██████████| 399/399 [00:15<00:00, 26.55it/s]
fatal: not a git repository (or any of the parent directories): .git
2026-05-21 06:05:16,662 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/031a87d2-6315-4b23-a0c7-2a55523759a4/events "HTTP/1.1 204 No Content"
2026-05-21 06:05:16,667 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/031a87d2-6315-4b23-a0c7-2a55523759a4/events "HTTP/1.1 204 No Content"
2026-05-21 06:05:16,668 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-05-21 06:05:16,669 - __main__ - INFO - ================================================================================
2026-05-21 06:05:16,669 - __main__ - INFO - Evaluation completed successfully
2026-05-21 06:05:16,669 - __main__ - INFO - Overall score: 0.64
2026-05-21 06:05:16,669 - __main__ - INFO - Examples evaluated: 100
2026-05-21 06:05:16,669 - __main__ - INFO - Duration: 20.38s
2026-05-21 06:05:16,669 - __main__ - INFO - ================================================================================
2026-05-21 06:05:16,673 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/031a87d2-6315-4b23-a0c7-2a55523759a4/events "HTTP/1.1 204 No Content"
2026-05-21 06:05:16,674 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 4 | Score: 0.64
2026-05-21 06:05:16,674 - evalhub.adapter.callbacks - INFO - Job 031a87d2-6315-4b23-a0c7-2a55523759a4 completed | Benchmark: arc_easy | Model: meta-llama/Llama-3.2-1B-Instruct | Score: 0.64 | Examples: 100 | Duration: 20.38s

```
3. Evaluation job with collection

```
{
  "resource": {
    "id": "2d736ee5-612b-497f-a14a-b3d6b387a891",
    "tenant": "dataplane",
    "created_at": "2026-05-21T06:06:32.416904Z",
    "updated_at": "2026-05-21T06:11:24.372796Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "bigbench_hhh_alignment_multiple_choice",
        "benchmark_index": 2,
        "status": "completed",
        "completed_at": "2026-05-21T06:07:34.939408+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "toxigen",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-05-21T06:09:18.987911+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "truthfulqa_mc1",
        "benchmark_index": 1,
        "status": "completed",
        "completed_at": "2026-05-21T06:11:24.363971+00:00"
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "bigbench_hhh_alignment_multiple_choice",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 2,
        "metrics": {
          "acc": 0.4253393665158371,
          "acc_stderr": 0.03333206140201842
        }
      },
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.4074468085106383,
          "acc_norm": 0.42872340425531913,
          "acc_norm_stderr": 0.016150241325972998,
          "acc_stderr": 0.01603490291675187
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 1,
        "metrics": {
          "acc": 0.2729498164014688,
          "acc_stderr": 0.01559475363200653
        }
      }
    ]
  },
  "name": "model offline test using collection",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct"
  },
  "collection": {
    "id": "toxicity-and-ethical-principles",
    "benchmarks": [
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_toxigen/",
            "secret_ref": "minio-test"
          }
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_truthful_qa/",
            "secret_ref": "minio-test"
          }
        }
      },
      {
        "id": "bigbench_hhh_alignment_multiple_choice",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_bigbench/",
            "secret_ref": "minio-test"
          }
        }
      }
    ]
  }
}
```
pod logs:
```oc logs 2d736ee5-612b-497f-a14a-b3-bd88453e-bc68-4c51-8b97-6bb2d86tkzlk   -f -n dataplane
Defaulted container "adapter" out of: adapter, init (init), sidecar (init)
2026-05-21 06:06:47,945 - evalhub.adapter.models.adapter - INFO - Loading job spec from /meta/job.json
2026-05-21 06:06:47,947 - __main__ - INFO - LMEval adapter initialized
2026-05-21 06:06:47,947 - __main__ - INFO - ================================================================================
2026-05-21 06:06:47,947 - __main__ - INFO - LMEval EvalHub Adapter
2026-05-21 06:06:47,947 - __main__ - INFO - ================================================================================
2026-05-21 06:06:47,947 - __main__ - INFO - Loaded job spec from: /meta/job.json
2026-05-21 06:06:47,947 - __main__ - INFO - Job spec configuration:
2026-05-21 06:06:47,947 - __main__ - INFO -   Job ID: 2d736ee5-612b-497f-a14a-b3d6b387a891
2026-05-21 06:06:47,947 - __main__ - INFO -   Benchmark: truthfulqa_mc1
2026-05-21 06:06:47,947 - __main__ - INFO -   Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-21 06:06:47,947 - __main__ - INFO -   Examples: None
2026-05-21 06:06:47,947 - __main__ - INFO -   Few-shot: None
2026-05-21 06:06:47,947 - __main__ - INFO - ================================================================================
2026-05-21 06:06:47,947 - __main__ - INFO - Callback URL: http://localhost:8080
2026-05-21 06:06:47,947 - __main__ - INFO - Provider ID: lm_evaluation_harness
2026-05-21 06:06:47,947 - __main__ - INFO - OCI registry auth config present: False
2026-05-21 06:06:47,947 - __main__ - INFO - OCI insecure: False
2026-05-21 06:06:47,947 - __main__ - INFO - EvalHub insecure: False
2026-05-21 06:06:47,947 - __main__ - INFO - ================================================================================
2026-05-21 06:06:47,980 - __main__ - INFO - HF offline mode (auto-detected from parameters.tokenizer + /test_data): HF_HOME=/test_data, downloads disabled
2026-05-21 06:06:47,980 - __main__ - INFO - Concurrent requests are disabled (num_concurrent=1). Add num_concurrent to benchmark parameters to enable.
2026-05-21 06:06:48,008 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/2d736ee5-612b-497f-a14a-b3d6b387a891/events "HTTP/1.1 204 No Content"
2026-05-21 06:06:48,032 - __main__ - INFO - Job ID: 2d736ee5-612b-497f-a14a-b3d6b387a891
2026-05-21 06:06:48,032 - __main__ - INFO - Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-21 06:06:48,032 - __main__ - INFO - Benchmark: truthfulqa_mc1
2026-05-21 06:06:48,032 - __main__ - INFO - Examples limit: None
2026-05-21 06:06:48,032 - __main__ - INFO - Few-shot: 0
2026-05-21 06:06:48,032 - __main__ - INFO - Device: cpu (forced)
2026-05-21 06:06:48,032 - __main__ - INFO - Model backend: local-completions
2026-05-21 06:06:48,037 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/2d736ee5-612b-497f-a14a-b3d6b387a891/events "HTTP/1.1 204 No Content"
2026-05-21 06:06:51,146 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/2d736ee5-612b-497f-a14a-b3d6b387a891/events "HTTP/1.1 204 No Content"
2026-05-21 06:06:51,148 - lm_eval.evaluator - INFO - Setting random seed to 42 | Setting numpy seed to 42 | Setting torch manual seed to 42 | Setting fewshot manual seed to 1234
2026-05-21 06:06:51,148 - lm_eval.evaluator - INFO - Initializing local-completions model, with arguments: {'model': 'meta-llama/Llama-3.2-1B-Instruct', 'base_url': 'https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions', 'tokenizer_backend': 'huggingface', 'tokenizer': '/test_data/tokenizer', 'tokenized_requests': False, 'num_concurrent': 1, 'batch_size': 1, 'timeout': 300}
2026-05-21 06:06:51,148 - lm_eval.models.api_models - INFO - Using max length 2048 - 1
2026-05-21 06:06:51,148 - lm_eval.models.api_models - INFO - Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2026-05-21 06:06:51,148 - lm_eval.models.api_models - INFO - Using tokenizer huggingface
2026-05-21 06:06:51,773 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/truthful_qa--multiple_choice
2026-05-21 06:06:51,864 - lm_eval.evaluator - INFO - num_fewshot has been set to 0 for truthfulqa_mc1 in its config. Manual configuration will be ignored.
2026-05-21 06:06:51,864 - lm_eval.api.task - INFO - Building contexts for truthfulqa_mc1 on rank 0...
100%|██████████| 817/817 [00:01<00:00, 514.43it/s]
2026-05-21 06:06:53,550 - lm_eval.evaluator - INFO - Running loglikelihood requests
Requesting API: 100%|██████████| 4114/4114 [04:24<00:00, 15.55it/s]
fatal: not a git repository (or any of the parent directories): .git
2026-05-21 06:11:24,363 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/2d736ee5-612b-497f-a14a-b3d6b387a891/events "HTTP/1.1 204 No Content"
2026-05-21 06:11:24,367 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/2d736ee5-612b-497f-a14a-b3d6b387a891/events "HTTP/1.1 204 No Content"
2026-05-21 06:11:24,368 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-05-21 06:11:24,371 - __main__ - INFO - ================================================================================
2026-05-21 06:11:24,371 - __main__ - INFO - Evaluation completed successfully
2026-05-21 06:11:24,371 - __main__ - INFO - Overall score: 0.2729498164014688
2026-05-21 06:11:24,371 - __main__ - INFO - Examples evaluated: 817
2026-05-21 06:11:24,371 - __main__ - INFO - Duration: 276.38s
2026-05-21 06:11:24,371 - __main__ - INFO - ================================================================================
2026-05-21 06:11:24,375 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/2d736ee5-612b-497f-a14a-b3d6b387a891/events "HTTP/1.1 204 No Content"
2026-05-21 06:11:24,375 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 2 | Score: 0.2729498164014688
2026-05-21 06:11:24,375 - evalhub.adapter.callbacks - INFO - Job 2d736ee5-612b-497f-a14a-b3d6b387a891 completed | Benchmark: truthfulqa_mc1 | Model: meta-llama/Llama-3.2-1B-Instruct | Score: 0.2729498164014688 | Examples: 817 | Duration: 276.38s

```
