### PR TITLE
fix(tasks): update anli dataset_path to facebook/anli

### DIFF
--- a/lm_eval/tasks/anli/anli_r1.yaml
+++ b/lm_eval/tasks/anli/anli_r1.yaml
@@ -1,7 +1,7 @@
 tag:
   - anli
 task: anli_r1
-dataset_path: anli
+dataset_path: facebook/anli
 dataset_name: null
 output_type: multiple_choice
 training_split: train_r1

--- a/lm_eval/tasks/benchmarks/t0_eval.yaml
+++ b/lm_eval/tasks/benchmarks/t0_eval.yaml
@@ -52,7 +52,7 @@ task:
         ignore_case: true
         ignore_punctuation: true
   - task: anli_r1
-    dataset_path: anli
+    dataset_path: facebook/anli
     use_prompt: promptsource:*
     training_split: train_r1
     validation_split: dev_r1
@@ -64,7 +64,7 @@ task:
         ignore_case: true
         ignore_punctuation: true
   - task: anli_r2
-    dataset_path: anli
+    dataset_path: facebook/anli
     use_prompt: promptsource:*
     training_split: train_r2
     validation_split: dev_r2
@@ -76,7 +76,7 @@ task:
         ignore_case: true
         ignore_punctuation: true
   - task: anli_r3
-    dataset_path: anli
+    dataset_path: facebook/anli
     use_prompt: promptsource:*
     training_split: train_r3
     validation_split: dev_r3


### PR DESCRIPTION
The `anli` dataset was renamed to `facebook/anli` on HuggingFace. The `huggingface_hub` library now requires the full `namespace/name` format, causing HfUriError when loading the dataset with the old short name.

Updated `dataset_path` from `anli` to `facebook/anli` in:
- lm_eval/tasks/anli/anli_r1.yaml (inherited by anli_r2, anli_r3)
- lm_eval/tasks/benchmarks/t0_eval.yaml (anli_r1, anli_r2, anli_r3)

Aligns with upstream EleutherAI/lm-evaluation-harness.